### PR TITLE
Allow to train even when no GPU available

### DIFF
--- a/src/python/piper_train/__main__.py
+++ b/src/python/piper_train/__main__.py
@@ -125,11 +125,13 @@ def main():
     else:
         torch.manual_seed(args.seed)
         _LOGGER.debug("Using manual seed: %s", args.seed)
-    
+
     # Function to check if the GPU supports Tensor Cores
     def supports_tensor_cores():
         # Assuming that Tensor Cores are supported if the compute capability is 7.0 or higher
         # This is a simplification; you might need a more detailed check based on your specific requirements
+        if args.accelerator == "cpu":
+            return False
         return torch.cuda.get_device_capability(0)[0] >= 7
 
     # Set the float32 matrix multiplication precision based on GPU support for Tensor Cores


### PR DESCRIPTION
This bugfix allows to train when only CPU is available.

Previously when the --accelerator cpu option was given by the user, without a GPU, the train process stopped with error:

  RuntimeError: Found no NVIDIA driver on your system. Please check that
  you have an NVIDIA GPU and installed a driver from
  http://www.nvidia.com/Download/index.aspx

Now, when I pass the 'cpu' option and I do not have a GPU, I'm able to train.

